### PR TITLE
Added default executor modifiable for tests.

### DIFF
--- a/vbm_test.go
+++ b/vbm_test.go
@@ -1,12 +1,11 @@
 package virtualbox
 
 import (
+	"context"
+	"io"
+	"os"
 	"testing"
 )
-
-func init() {
-	Verbose = true
-}
 
 func TestVBMOut(t *testing.T) {
 	b, err := vbmOut("list", "vms")
@@ -14,4 +13,23 @@ func TestVBMOut(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("%s", b)
+}
+
+func setup() {
+	Verbose = true
+
+	defaultExecutor = mockExecutor
+}
+
+func TestMain(m *testing.M) {
+	setup()
+	os.Exit(m.Run())
+}
+
+func mockExecutor(ctx context.Context, so io.Writer, se io.Writer, args ...string) error {
+	// TODO: By returning nil we are causing all the tests to pass because the
+	//       current ones do not check the output of the command. Here we would
+	//       keep the state of the machines, immitating VBoxManage - thus
+	//       eliminating it as a dependency.
+	return nil
 }


### PR DESCRIPTION
The executor abstraction allows us to introduce a mock executor, which removes
the need for VBoxManage installed on the box, as well as introducting various
failure scenarios which could then be tested and improve the reliability of the
project.

With the current implementation, the mock executor always returns nil, and
allows all tests to pass. This behaviour should be changed in the future,
perhaps adapted even more with closures to allow the list of items that should
be returned as output.

In its current state, the function signature should remain the same.