### PR TITLE
Remove Use of Unsupported --synthcpu Flag

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -37,7 +37,6 @@ const (
 	CPUHOTPLUG
 	PAE
 	LONGMODE
-	SYNTHCPU
 	HPET
 	HWVIRTEX
 	TRIPLEFAULTRESET
@@ -377,7 +376,6 @@ func (m *Machine) Modify() error {
 		"--cpuhotplug", m.Flag.Get(CPUHOTPLUG),
 		"--pae", m.Flag.Get(PAE),
 		"--longmode", m.Flag.Get(LONGMODE),
-		"--synthcpu", m.Flag.Get(SYNTHCPU),
 		"--hpet", m.Flag.Get(HPET),
 		"--hwvirtex", m.Flag.Get(HWVIRTEX),
 		"--triplefaultreset", m.Flag.Get(TRIPLEFAULTRESET),


### PR DESCRIPTION
Judging from [these](https://github.com/docker/machine/issues/1387) [issues](https://github.com/Whonix/Whonix/commit/6db3c345c80ee9841fcae57621cafbfcdd000a0f) and [commits](https://github.com/hheimbuerger/boot2docker-cli/commit/b983c3e183fd22d6f5b2202c0a179410dbcef80e), `--synthcpu` flag was removed from Virtualbox a couple of major version ago.

It looks like it was also removed from this library [once](https://github.com/terra-farm/go-virtualbox/commit/b4be149a9fc32b425cdce5a538d425883530bc9e) already, but re-introduced in [this commit](https://github.com/terra-farm/go-virtualbox/commit/84ae0c05a68380047f753a30d6330d7fd69652a5). Not sure if this was intentional, but it breaks VM creation at least for me (running Virtualbox 6.1).

This PR completely removes it again, as unsure if we need to keep compatibility for Virtualbox versions < 5 ? If we do, will need to rework to conditionally use this flag.