### PR TITLE
Return error message in Start Machine.

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -2,6 +2,8 @@ package virtualbox
 
 import (
 	"bufio"
+	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -98,14 +100,22 @@ func (m *Machine) Refresh() error {
 	return nil
 }
 
-// Start starts the machine.
+// Start the machine, and return the underlying error when unable to do so.
 func (m *Machine) Start() error {
+	var args []string
+
 	switch m.State {
 	case Paused:
-		return Manage().run("controlvm", m.Name, "resume")
+		args = []string{"controlvm", m.Name, "resume"}
 	case Poweroff, Saved, Aborted:
-		return Manage().run("startvm", m.Name, "--type", "headless")
+		args = []string{"startvm", m.Name, "--type", "headless"}
 	}
+
+	_, msg, err := Run(context.Background(), args...)
+	if err != nil {
+		return errors.New(msg)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The default error with the exit code is not very informative. Instead, we will now return the stderr in case of an error in running the command.

Example output when running in terraform-provider-virtualbox:

```
Error: unable to start VM: VBoxManage: error: Nonexistent host networking interface, name 'vboxnet1' (VERR_INTERNAL_ERROR)
│ VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component ConsoleWrap, interface IConsole
│ 
│ 
│   with virtualbox_vm.node[1],
│   on example.tf line 14, in resource "virtualbox_vm" "node":
│   14: resource "virtualbox_vm" "node" {
```