### PR TITLE
feat: allow reading and setting firmware

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -65,6 +65,7 @@ func (f Flag) Get(o Flag) string {
 // Machine information.
 type Machine struct {
 	Name       string
+	Firmware   string
 	UUID       string
 	State      MachineState
 	CPUs       uint
@@ -252,6 +253,7 @@ func GetMachine(id string) (*Machine, error) {
 	/* Extract basic info */
 	m := New()
 	m.Name = propMap["name"]
+	m.Firmware = propMap["firmware"]
 	m.UUID = propMap["UUID"]
 	m.State = MachineState(propMap["VMState"])
 	n, err := strconv.ParseUint(propMap["memory"], 10, 32)
@@ -369,7 +371,7 @@ func CreateMachine(name, basefolder string) (*Machine, error) {
 // Modify changes the settings of the machine.
 func (m *Machine) Modify() error {
 	args := []string{"modifyvm", m.Name,
-		"--firmware", "bios",
+		"--firmware", m.Firmware,
 		"--bioslogofadein", "off",
 		"--bioslogofadeout", "off",
 		"--bioslogodisplaytime", "0",


### PR DESCRIPTION
Hi,
With these changes information regarding firmware is propagated and can be set by overriding `Machine.Firmware` followed by a call to `Machine.Modify()`. I need this to create VMs which only support EFI boot, will also submit a PR for your terraform provider if you accept this.
Thank you,
Thomas