### PR TITLE
Add machine interface

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,26 @@
+package virtualbox
+
+import "context"
+
+// Virtualbox interface defines all the actions which can be performed by the
+// Manager. This is mostly a utility interface designed for the customers of the
+// package.
+type Virtualbox interface {
+	MachineManager
+}
+
+// MachineManager defines the actions that can be performed to manage machines
+type MachineManager interface {
+	// Machine gets a machine name based on its name or UUID
+	Machine(context.Context, string) (*Machine, error)
+
+	// ListMachines returns a list of all machines
+	ListMachines(context.Context) ([]*Machine, error)
+
+	// UpdateMachine allows to update the machine. The returned is the machine
+	// in the current state after the update.
+	UpdateMachine(context.Context, *Machine) (*Machine, error)
+
+	// DeleteMachine deletes a machine by its name or UUID
+	DeleteMachine(context.Context, string) error
+}


### PR DESCRIPTION
This interface will be used as a new method of interacting with the package.
It will use an instanciated client to perform actions, allowing for better testing on
the consumer side.

This change is a partial implementation of #26, but split a bit better to avoid doing too much in one change.