### PR TITLE
Don't use cache on lint

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,14 +53,6 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
     - uses: golangci/golangci-lint-action@v3
 
   build:


### PR DESCRIPTION
It seems like the linter has its own caching or something because it keeps
on complaining when used with cache.