### PR TITLE
Remove OS matrix builds

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,16 +60,14 @@ jobs:
     needs: vendor
     strategy:
       matrix:
-        os:
-        - ubuntu-latest
-        - windows-latest
-        - macOS-latest
         go:
         - "1.19"
         - "1.18"
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go }}
     - uses: actions/checkout@v3
     - uses: actions/cache@v3
       with:


### PR DESCRIPTION
For now while we don't test with actual Virtualbox instance we don't need to
test across different platforms. Once we add integration tests then we should
add it again, but for now its just a waste of time and CPU.