### PR TITLE
Make regular expression for guestproperty extraction case insensitive

### DIFF
--- a/guestprop.go
+++ b/guestprop.go
@@ -15,7 +15,7 @@ type GuestProperty struct {
 }
 
 var (
-	getRegexp  = regexp.MustCompile("(?m)^Value: ([^,]*)$")
+	getRegexp  = regexp.MustCompile("(?mi)^Value: ([^,]*)$")
 	waitRegexp = regexp.MustCompile("^Name: ([^,]*), value: ([^,]*), flags:.*$")
 )
 

--- a/guestprop_test.go
+++ b/guestprop_test.go
@@ -36,6 +36,18 @@ func TestGuestProperty(t *testing.T) {
 	if val != "test_val" {
 		t.Fatal("Wrong value")
 	}
+	if ManageMock != nil {
+		ManageMock.EXPECT().isGuest().Return(false)
+		ManageMock.EXPECT().run("guestproperty", "get", VM, "test_key").Return("value: test_val", "", nil).Times(1)
+	}
+	val_lowercase, err := GetGuestProperty(VM, "test_key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("val='%s'", val_lowercase)
+	if val_lowercase != "test_val" {
+		t.Fatal("Wrong value")
+	}
 	Debug("OK GetGuestProperty test_key=test_val")
 
 	// Now deletes it...


### PR DESCRIPTION
When investigating on the [issue 149 in the terra-farm/terraform-provider-virtualbox repository](https://github.com/terra-farm/terraform-provider-virtualbox/issues/149) I found out that the issue mentioned there was not part of the provider but of the go interface for virtualbox.

The regular expression which extracts the value from the `guestproperty get` command only checks for `Value` written in that exact case. For my installation of VirtualBox this doesn't match. My output from `guestproperty get` looks like this:
```
Name: /VirtualBox/GuestInfo/Net/0/V4/IP, value: 192.168.56.118, timestamp: 1666676579936956000, flags:
```
I've changed the regex so that it should allow both and provided a new test case for this.
Please let me know if you need further information on something.
Thanks in advance!