### PR TITLE
Change the hardware address of a network interface created

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -208,6 +208,9 @@ func (m *Manager) ModifyMachine(ctx context.Context, vm *Machine) error {
 		} else if nic.Network == NICNetBridged {
 			args = append(args, fmt.Sprintf("--bridgeadapter%d", n), nic.HostInterface)
 		}
+		if nic.MacAddr != "" {
+			args = append(args, fmt.Sprintf("--macaddress%d", n), nic.MacAddr)
+		}
 	}
 
 	if _, _, err := m.run(ctx, args...); err != nil {


### PR DESCRIPTION
This change allows to pass the hardware address of a network interface in the `MacAddr` field. The pre-determined mac address can be set on the network interface. It is useful if a fixed mac address is required when deploying a VM