### PR TITLE
In virtualbox 7, the parameter bridgeadapter was renamed to bridge-ad…

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -117,7 +117,7 @@ func (m *Manager) Machine(ctx context.Context, id string) (*Machine, error) {
 		if nic.Network == NICNetHostonly {
 			nic.HostInterface = props[fmt.Sprintf("hostonlyadapter%d", i)]
 		} else if nic.Network == NICNetBridged {
-			nic.HostInterface = props[fmt.Sprintf("bridgeadapter%d", i)]
+			nic.HostInterface = props[fmt.Sprintf("bridge-adapter%d", i)]
 		}
 		vm.NICs = append(vm.NICs, nic)
 	}


### PR DESCRIPTION
In virtualbox 7, the parameter `bridgeadapter` was renamed to `bridge-adapter`.
https://www.virtualbox.org/manual/ch08.html#vboxmanage-modifyvm

`--bridge-adapterN=none | device-name`

Specifies the host interface to use for the specified virtual network interface. 